### PR TITLE
fix: use process.env in firebase backend

### DIFF
--- a/Backend/firebase.js
+++ b/Backend/firebase.js
@@ -1,3 +1,6 @@
+import dotenv from "dotenv";
+dotenv.config({ path: "../.env.local" });
+
 import { initializeApp } from "firebase/app";
 import { getFirestore } from "firebase/firestore";
 

--- a/Backend/firebase.js
+++ b/Backend/firebase.js
@@ -2,12 +2,12 @@ import { initializeApp } from "firebase/app";
 import { getFirestore } from "firebase/firestore";
 
 const firebaseConfig = {
-  apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
-  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
-  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
-  storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET,
-  messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
-  appId: import.meta.env.VITE_FIREBASE_APP_ID
+  apiKey: process.env.VITE_FIREBASE_API_KEY,
+  authDomain: process.env.VITE_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.VITE_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.VITE_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.VITE_FIREBASE_APP_ID
 };
 
 const app = initializeApp(firebaseConfig);

--- a/Backend/server.js
+++ b/Backend/server.js
@@ -1,10 +1,7 @@
 import express from "express";
 import cors from "cors";
-import dotenv from "dotenv";
 import routes from "./services.js";
 
-// this loads .env variables into process.env
-dotenv.config();
 
 const app = express();
 const PORT = 3000;


### PR DESCRIPTION
I accidentally reverted firebase.js to an older version that used `import.meta.env`.

Changed it back to `process.env` so it works again in the backend when running with Node.

This just restores the previous working version.
