### PR TITLE
add simple CartBtn component with dynamic count

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,10 +3,22 @@ import reactLogo from './assets/react.svg'
 import viteLogo from './assets/vite.svg'
 import heroImg from './assets/hero.png'
 import Products from "./Products";
+import CartBtn from './components/CartBtn';
+
+
 
 function App() {
+
+  const [cart, setCart] = useState([]);
+
   return (
     <div>
+       <CartBtn
+        count={cart.length}
+        onClick={() => {
+          console.log("Go to cart");
+        }}
+      />
       <Products />
     </div>
   );

--- a/frontend/src/components/CartBtn.jsx
+++ b/frontend/src/components/CartBtn.jsx
@@ -1,0 +1,16 @@
+import Btn from "./Btn";
+
+// Cart-knapp som återanvänder vår generella Btn-komponent
+function CartBtn({onClick, count = 0 }) {
+    return (
+    <Btn 
+    // vad som händer när man klickar (t.ex. gå till cart)
+    onClick={onClick} 
+    // visar ikon + antal om det finns produkter i cart
+    spanText={count > 0 ? `🛒 (${count})` : `🛒`} 
+    />
+    );
+
+}
+
+export default CartBtn;


### PR DESCRIPTION
* Added a simple CartBtn component
* Displays cart count dynamically
* Reuses existing Btn component

To provide a basic cart button that can easily be integrated into the navbar and expanded later.

Kept it minimal for now so it’s flexible to build on depending on how we structure the cart flow.
